### PR TITLE
fix #bind and #partial arguments propagation

### DIFF
--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -425,16 +425,16 @@ function _.after(times, func)
 end
 
 function _.bind(func, context, ...)
-  local arguments = unpack({...})
+  local arguments = {...}
   return function(...)
-    return func(context, unpack(_.concat(arguments,...)))
+    return func(context, unpack(_.concat(arguments, {...})))
   end
 end
 
 function _.partial(func, ...)
   local args = {...}
   return function(self, ...)
-    return func(self, _.concat(args, {...}))
+    return func(self, unpack(_.concat(args, {...})))
   end
 end
 

--- a/spec/functions_spec.lua
+++ b/spec/functions_spec.lua
@@ -106,7 +106,7 @@ describe("#partial", function()
   it("can partially apply arguments to a function", function()
     local obj = {name='moe'}
     local func = function(self, ...)
-      return self.name .. ' ' .. _(...):join(' ')
+      return self.name .. ' ' .. _({...}):join(' ')
     end
 
     obj.func = _.partial(func, 'a', 'b')


### PR DESCRIPTION
Fix bind and partial arguments propagation. this code snippet shows the error:

``` lua
obj = {}
function obj:test(p1, p2)
  _.print_r(p1)
  _.print_r(p2)
end

bind = _.bind(obj.test, obj)

bind({1, 2}, {3, 4})
```

without fix p1 == 1 and p2 == 2
with fix p1 == {1, 2} and p2 == {3, 4)
